### PR TITLE
Put a cap on how long to wait for definitions

### DIFF
--- a/htdocs/includes/class.Bill2.php
+++ b/htdocs/includes/class.Bill2.php
@@ -410,7 +410,7 @@ class Bill2
 			 * works.
 			 */
 			$url .= $code_sections[0]['section_number'];
-			$terms = get_content(urldecode($url));
+			$terms = get_content(urldecode($url), 1);
 			$terms = (array) json_decode($terms);
 			if (count($terms) == 0)
 			{

--- a/htdocs/includes/functions.inc.php
+++ b/htdocs/includes/functions.inc.php
@@ -726,12 +726,13 @@ function explain_status($status)
 }
 
 # A simple wrapper for CURL.
-function get_content($url)
+function get_content($url, $timeout=10)
 {
 	$ch = curl_init();
 	
 	curl_setopt ($ch, CURLOPT_URL, $url);
 	curl_setopt ($ch, CURLOPT_HEADER, 0);
+	curl_setopt ($ch, CURLOPT_TIMEOUT, $timeout);
 	
 	ob_start();
 	


### PR DESCRIPTION
Wait for no longer than 1 second. If it takes that long, skip embedding
definitions.