### PR TITLE
Fix constant name for logging

### DIFF
--- a/htdocs/includes/settings.inc.php
+++ b/htdocs/includes/settings.inc.php
@@ -70,7 +70,7 @@ define('MAPBOX_ID', '');
 define('MAPBOX_TOKEN', '');
 
 # Logging verbosity, on a scale of 1–8
-define('LOGGING_VERBOSITY', 3);
+define('LOG_VERBOSITY', 3);
 
 # Slack API URL
 define('SLACK_WEBHOOK', '');


### PR DESCRIPTION
Well, that’ll do it. Closes #155.