### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy Process
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openva/richmondsunlight.com/security/code-scanning/2](https://github.com/openva/richmondsunlight.com/security/code-scanning/2)

To fix the problem, we must add a `permissions:` block to the workflow. The recommended approach is to put it at the top-level (right after `name:` or before `jobs:`) so the specified permissions apply to all jobs unless overridden in a specific job. According to the principle of least privilege and the recommendations provided, the minimal necessary permission is usually `contents: read`. If any steps require additional access (like creating pull requests, writing to issues, etc.), those should be added specifically. In this workflow, no steps appear to require write access to repo contents, issues, or PRs; so setting `contents: read` is appropriate. The change needs to be implemented at the top of `.github/workflows/deploy.yml`, right after the workflow `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
