### PR TITLE
Hotfix: Re-add winnowing-down of API response

### DIFF
--- a/htdocs/includes/class.Import.php
+++ b/htdocs/includes/class.Import.php
@@ -94,6 +94,9 @@ class Import
             return [];
         }
 
+        // All bills are a subset of the 'Legislations' key
+        $response = $response['Legislations'];
+
         $list = [];
         foreach ($response as $item) {
             if (!is_array($item)) {


### PR DESCRIPTION
We lost this in an update. #815