### PR TITLE
Fix array access error in Comments::get() for Photosynthesis comments

### DIFF
--- a/htdocs/includes/class.Comments.php
+++ b/htdocs/includes/class.Comments.php
@@ -127,7 +127,8 @@ class Comments
                     $comment['type'] = 'photosynthesis';
 
                     // Add this comment to the comments array.
-                    $comments[$comment]['timestamp'] = $comment;
+                    $commentTimestamp = $comment['timestamp'];
+                    $comments[$commentTimestamp] = $comment;
                 }
             }
         }


### PR DESCRIPTION
Fixed TypeError on line 130 where $comment array was incorrectly used
as an array key instead of $comment['timestamp']. This error only
occurred when bills had Photosynthesis-type comments.