### PR TITLE
Fix count(null) error in minutes.php for PHP 8+ compatibility

### DIFF
--- a/htdocs/minutes.php
+++ b/htdocs/minutes.php
@@ -253,12 +253,14 @@ if (mysqli_num_rows($result) == 0) {
 
         $video2->clip_type = 'bills';
         $video2->get_clips();
+        $bill_clips = [];
         if (isset($video2->clips)) {
             $bill_clips = $video2->clips;
         }
 
         $video2->clip_type = 'legislators';
         $video2->index_clips();
+        $legislator_clips = [];
         if (isset($video2->clips)) {
             $legislator_clips = $video2->clips;
         }
@@ -269,7 +271,7 @@ if (mysqli_num_rows($result) == 0) {
 
         if (
             isset($video['html']) &&
-            (count($bill_clips) > 0 || count($legislator_clips) > 0 || count($video2->screenshots) > 0)
+            (count($bill_clips) > 0 || count($legislator_clips) > 0 || (isset($video2->screenshots) && count((array)$video2->screenshots) > 0))
         ) {
             $page_body .= '<h3>Index</h3>
 				<div id="video-index" class="tabs">


### PR DESCRIPTION
Newer versions of PHP (8.0+) throw a TypeError when count() is called
with null values. This fixes the issue by:

1. Initializing $bill_clips and $legislator_clips as empty arrays
   before conditionally setting them
2. Adding isset() check and array cast for $video2->screenshots
   before counting

Fixes #925