### PR TITLE
Remove persistent connections

### DIFF
--- a/htdocs/includes/class.Database.php
+++ b/htdocs/includes/class.Database.php
@@ -36,7 +36,7 @@ class Database
          * Connect with persistent connection and optimized settings
          */
         $options = [
-            PDO::ATTR_PERSISTENT => true,
+            PDO::ATTR_PERSISTENT => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
             PDO::ATTR_EMULATE_PREPARES => false,
@@ -82,7 +82,7 @@ class Database
 
         $previous_reporting = mysqli_report(MYSQLI_REPORT_OFF);
         try {
-            $this->db = mysqli_connect('p:' . PDO_SERVER, PDO_USERNAME, PDO_PASSWORD);
+            $this->db = mysqli_connect(PDO_SERVER, PDO_USERNAME, PDO_PASSWORD);
         } catch (mysqli_sql_exception $e) {
             $this->db = false;
         } finally {

--- a/htdocs/php.ini
+++ b/htdocs/php.ini
@@ -1,18 +1,7 @@
-; Enable persistent connections (already enabled by default, but explicit is better)
-mysqli.allow_persistent = On
-
-; Limit persistent connections per PHP-FPM worker process
-; -1 means unlimited, but setting a reasonable limit prevents resource exhaustion
-; Each PHP-FPM worker can maintain up to 10 persistent connections
-mysqli.max_persistent = 10
-
-; Maximum number of total connections (persistent + non-persistent) per worker
-; -1 means unlimited
+; Disable persistent connections to prevent connection slot exhaustion
+mysqli.allow_persistent = Off
+mysqli.max_persistent = 0
 mysqli.max_links = -1
-
-; Automatically rollback transactions on cached persistent links
-; This prevents transaction state from leaking between requests
-mysqli.rollback_on_cached_plink = 1
 
 ; Enable OPcache for better PHP performance (reduces load, indirectly helps DB)
 opcache.enable = 1


### PR DESCRIPTION
I think it may have actually made things worse, because we're exhausting MariaDB's connection pool. #788